### PR TITLE
add ability to use != in Group location condition

### DIFF
--- a/class/custom_group.php
+++ b/class/custom_group.php
@@ -39,7 +39,7 @@ class CustomGroup extends CustomFieldContainer {
 			foreach ( $rules as $r => $rule ) {
 				$rule = trim( $rule );
 				
-				if ( preg_match_all( '/(.+)\s*(==)\s*(.*)/', $rule, $matches ) ) {
+				if ( preg_match_all( '/(.+)\s*(==|!=)\s*(.*)/', $rule, $matches ) ) {
 					$rules[$r] = array(
 						'param' => trim( $matches[1][0] ),
 						'operator' => trim( $matches[2][0] ),


### PR DESCRIPTION
Hey,
can you please merge this small regex change, so we can be able to use NOT EQUAL conditions when defining Group locations?

Thanks.